### PR TITLE
account for AURA_MAGE => ALCHEMIST rename

### DIFF
--- a/Magiclysm Attunement Unlock.json
+++ b/Magiclysm Attunement Unlock.json
@@ -6,9 +6,9 @@
     "cancels": []
   },
   {
-    "id": "AURA_MAGE",
+    "id": "ALCHEMIST",
     "type": "mutation",
-    "copy-from": "AURA_MAGE",
+    "copy-from": "ALCHEMIST",
     "cancels": []
   },
   {


### PR DESCRIPTION
AURA_MAGE had its ID renamed to ALCHEMIST in https://github.com/CleverRaven/Cataclysm-DDA/pull/49811